### PR TITLE
Mark numpy 1.24.0 as non-compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ dash~=2.6.1
 giotto-tda==0.6.0
 autodocsumm
 sphinx_rtd_theme
-numpy==1.21.6
+numpy==1.21.6, !=1.24.0
 pandas==1.2.5
 typing~=3.7.4.3
 scikit-learn~=1.0.2


### PR DESCRIPTION
Changes according to https://github.com/aimclub/FEDOT/pull/1013